### PR TITLE
Remove fuzzy deferred key matching.

### DIFF
--- a/src/commands/Examples.js
+++ b/src/commands/Examples.js
@@ -36,7 +36,7 @@ const Examples = {
       const targetKey = args.join('_').toLowerCase();
       const target = examples.find(
         ({ name }) =>
-          name === targetKey || args.every(arg => name.includes(arg.toLowerCase()))
+          name === targetKey || name.split('_').every(frag => targetKey.includes(frag))
       );
 
       // Fuzzy search examples

--- a/src/tests/commands.test.js
+++ b/src/tests/commands.test.js
@@ -156,14 +156,6 @@ describe('commands/Examples', () => {
     expect(output.embed.description.includes('Tags')).toBe(true);
   });
 
-  it('fuzzily gets a result by partial key', async () => {
-    const msg = await sendMessage(client, `${config.prefix}examples geometry_colors`);
-
-    const [output] = msg.channel.messages;
-    expect(output.embed.title).toBe('webgl_geometry_colors');
-    expect(output.embed.description.includes('Tags')).toBe(true);
-  });
-
   it('fuzzily gets a result by key', async () => {
     const msg = await sendMessage(
       client,


### PR DESCRIPTION
Fixes #8 by rolling back deferred key matching in favor of a query with all named keywords.