### PR TITLE
Revert /help removal.

### DIFF
--- a/src/commands/Help.js
+++ b/src/commands/Help.js
@@ -1,0 +1,26 @@
+import chalk from 'chalk';
+
+const Help = {
+  name: 'help',
+  description: "Displays this bot's commands.",
+  execute({ commands }) {
+    try {
+      const commandList = commands.reduce((list, { name, options, description }) => {
+        const args = options?.map(({ name }) => ` \`${name}\``) || '';
+
+        list += `\n**/${name}**${args} - ${description}`;
+
+        return list;
+      }, '');
+
+      return {
+        content: `**Commands**:\n${commandList}`,
+        ephemeral: true,
+      };
+    } catch (error) {
+      console.error(chalk.red(`/help >> ${error.stack}`));
+    }
+  },
+};
+
+export default Help;

--- a/src/tests/commands.test.js
+++ b/src/tests/commands.test.js
@@ -14,6 +14,15 @@ beforeAll(async () => {
     client.commands.get(name).execute({ ...client, options });
 });
 
+describe('/help', () => {
+  it("displays this bot's commands", async () => {
+    const output = await test('help');
+
+    expect(output.content.length).not.toBe(0);
+    expect(output.ephemeral).toBe(true);
+  });
+});
+
 describe('/docs', () => {
   it('has fallback on no result', async () => {
     const output = await test('docs', 'ThisDoesNotExist');


### PR DESCRIPTION
Reverts the removal of `/help` in 4fd834ff067132240fae7a2465ba5fc1abc0240e as an ephemeral command. Improves consistency for #17.