### PR TITLE
Use SPA path for docs' links.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,7 @@
  */
 export const THREE = {
   LOCALE: 'en', // en, ar, zh, ko, ja
-  DOCS_URL: 'https://threejs.org/docs/',
+  DOCS_URL: 'https://threejs.org/docs/#',
   DOCS_LIST: 'https://threejs.org/docs/list.json',
   EXAMPLES_URL: 'https://threejs.org/examples/',
   EXAMPLES_LIST: 'https://threejs.org/examples/files.json',

--- a/src/utils/discord.js
+++ b/src/utils/discord.js
@@ -88,7 +88,7 @@ export const sanitizeHTML = html =>
   html &&
   html
     // Transform code blocks
-    .replace(/<\/?code.*?>/gi, '```')
+    .replace(/<\/?code[^>]*?>/gi, '```')
     // Transform bold text
     .replace(/<\/?(h[0-9]|strong|b)>/gi, '**')
     // Transform italic text

--- a/src/utils/three.js
+++ b/src/utils/three.js
@@ -54,8 +54,8 @@ export const sanitizeMeta = meta =>
  */
 export const getElement = async (element, property) => {
   try {
-    // Fetch page and cleanup self-references
-    const response = await crawl(element.url);
+    // Fetch source page and cleanup self-references
+    const response = await crawl(element.url.replace('#api', 'api'));
     const html = response.replace(/(:)this|\[name\]/g, `$1${element.name}`);
 
     // Create context, get page elements


### PR DESCRIPTION
Currently, source documents are being fetched with three's custom markdown.

These pages aren't reactive like their SPA counterparts, so appending a property or method in the path will not scroll to its text.